### PR TITLE
Bugfix for linux

### DIFF
--- a/application/config/autoload.php
+++ b/application/config/autoload.php
@@ -64,7 +64,7 @@ $autoload['packages'] = array(
 |	$autoload['libraries'] = array('user_agent' => 'ua');
 */
 //$autoload['libraries'] = array();
-$autoload['libraries'] = array('smarty', 'form_validation', 'logs', 'utils', 'imgs', 'JPHPMailer', 'PHPExcel');
+$autoload['libraries'] = array('smarty', 'form_validation', 'logs', 'utils', 'imgs', 'JPHPMailer' => 'jphpmailer', 'PHPExcel');
 /*
 | -------------------------------------------------------------------
 |  Auto-load Drivers

--- a/application/libraries/Imgs.php
+++ b/application/libraries/Imgs.php
@@ -1,7 +1,7 @@
 <?php
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-$logClassFile = dirname(__FILE__) . '/logs.php';
+$logClassFile = dirname(__FILE__) . '/Logs.php';
 require_once $logClassFile;
 
 class Imgs extends Logs

--- a/application/libraries/Utils.php
+++ b/application/libraries/Utils.php
@@ -1,7 +1,7 @@
 <?php
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-$logClassFile = dirname(__FILE__) . '/logs.php';
+$logClassFile = dirname(__FILE__) . '/Logs.php';
 require_once $logClassFile;
 
 class Utils extends Logs


### PR DESCRIPTION
Linux環境で動かすと大文字、小文字の差分でエラーになっていたので、エラー対応をしました。
同じようにjPHPMailerのファイル名とクラス名の大文字小文字の違いがCodeIgniter3で許容されていなかったので対応を追加しています。
